### PR TITLE
Edited path output for files

### DIFF
--- a/WebGLExport/WebGLExport.py
+++ b/WebGLExport/WebGLExport.py
@@ -578,7 +578,8 @@ class WebGLExportLogic:
         if self.__copyFiles:
           fileName = os.path.split( file )[1]
           shutil.copy( file, os.path.join( self.__outputDir, fileName ) )
-          file = fileName
+        
+        file = os.path.split( file )[1]
 
         output += ' ' * 8 + mrmlId + '.file = "' + file + '";\n'
         output += ' ' * 8 + mrmlId + '.color = ' + color + ';\n'


### PR DESCRIPTION
Does not have absolute paths in the vtk/stl files, so just use relative path.  This allows Chrome to view exports if Chrome is default browser, otherwise you get "Cross origin requests are only supported for HTTP."
